### PR TITLE
Rename face inductive -> type

### DIFF
--- a/juvix-highlight.el
+++ b/juvix-highlight.el
@@ -24,7 +24,7 @@
   "The face used for functions."
   :group 'juvix-highlight-faces)
 
-(defface juvix-highlight-inductive-face
+(defface juvix-highlight-type-face
   '((((background light))
      (:foreground "#86b300"))
     (((background dark))


### PR DESCRIPTION
When we renamed `inductive` -> `type` the highlighter stopped working for inductive types.
This pr renames the face so that inductive types are properly highlighted again.