### PR TITLE
Rewrite most of juvix-mode

### DIFF
--- a/juvix-mode.el
+++ b/juvix-mode.el
@@ -1,14 +1,36 @@
+;;; juvix-mode --- Major mode for the Juvix programming language
+
+;;; Commentary:
+;;; See https://github.com/anoma/juvix-mode
 (require 'juvix-customize)
 (require 'juvix-highlight)
 (require 'juvix-input)
 (require 'flycheck-juvix)
 (require 'juvix-repl)
-
 (require 'posframe)
+
+;;; Code:
 
 (defgroup juvix nil
   "Major mode for Juvix files."
   :group 'languages)
+
+(defvar juvix-doc-buffer-name "*juvix-doc-buffer*")
+
+(defvar juvix-error-buffer-name "*juvix-error-buffer*")
+(defun juvix-error-buffer ()
+  "Return the juvix error buffer and create it if it does not exist."
+  (get-buffer-create juvix-error-buffer-name))
+
+(defvar juvix-log-buffer-name "*juvix-log-buffer*")
+(defun juvix-log-buffer ()
+  "Return the juvix log buffer and create it if it does not exist."
+  (get-buffer-create juvix-log-buffer-name))
+
+(defun juvix-log (FORMAT-STRING &rest ARGS)
+  "Format FORMAT-STRING with ARGS and print it to the juvix-log-buffer."
+  (with-current-buffer (juvix-log-buffer)
+    (insert (apply #'format FORMAT-STRING ARGS) "\n")))
 
 (defvar juvix-mode-map
   (let ((map (make-sparse-keymap))
@@ -23,15 +45,62 @@
 (add-to-list 'auto-mode-alist '("\\.juvix\\'" . juvix-mode))
 (add-to-list 'auto-mode-alist '("\\.juvix.md\\'" . juvix-mode))
 
+(defun juvix-get-global-flags ()
+  "Return the Juvix global flags as a list."
+  (interactive)
+  (append juvix-global-flags
+          (delq nil (list
+                     (if juvix-disable-embedded-stdlib "--no-stdlib" nil)
+                     (if juvix-stdlib-path (concat "--stdlib-path" juvix-stdlib-path) nil)))))
+
+(defun juvix-call (&optional STDOUT_BUFFER &rest ARGS)
+  "Call the Juvix compiler.
+
+Example: (call-juvix (current-buffer) \"dev\" \"root\")
+
+STDOUT_BUFFER specifies the buffer where the *standard output* goes.
+
+ARGS are the command-line arguments passed to the Juvix
+compiler.
+
+Returns the exit code of the Juvix command. A return
+value of 0 indicates success; any other value indicates failure.
+On failure, stderr will be pasted to juvix-error-buffer"
+
+                                        ; we create a temporary file to redirect stderr there. It is not possible to redirect to a buffer
+  (let ((tmp-err-file (make-temp-file "temporary-stderr-file")))
+    (with-temp-file tmp-err-file
+      (let* ((global-flags (juvix-get-global-flags))
+             (ALL_ARGS (append global-flags ARGS))
+             (destination (list STDOUT_BUFFER tmp-err-file))
+             (exit-code (apply #'call-process "juvix" nil destination nil ALL_ARGS)))
+        (unless (zerop exit-code)
+          (with-current-buffer (juvix-error-buffer)
+            (erase-buffer)
+            (goto-char (point-max))
+            (insert-file-contents tmp-err-file)
+            (display-buffer (juvix-error-buffer) 'display-buffer-at-bottom)
+            (message "Juvix failed. Read the error message in the buffer %s" juvix-error-buffer-name)))
+        exit-code))))
+
+(defun juvix-call-read (&rest ARGS)
+  "Call the Juvix compiler and return stdout or nil if it failed.
+
+ARGS are the command-line arguments passed to the Juvix
+compiler."
+  (with-temp-buffer
+    (let
+        ((exit-code (apply #'juvix-call (current-buffer) ARGS)))
+      (if (zerop exit-code)
+          (buffer-string)
+        nil))))
+
 (defun juvix-version ()
   "Return the juvix version."
-  (let ((version (car (split-string (shell-command-to-string "juvix --version")
-                                    "\n"))))
-    (if (string-prefix-p "Juvix" version)
-        version
-      "Juvix")))
-
-(defvar juvix-doc-buffer-name " *juvix-doc-buffer*")
+  (let ((res (juvix-call-read "--version")))
+    (if res
+        (car (split-string res "\n"))
+      nil)))
 
 (defun juvix-posframe-at-pt ()
   "Display type if available."
@@ -55,25 +124,28 @@
 
 (defun juvix-insert-top-module-name ()
   "Insert the suggested top module name."
+  ;; we save the buffer to guarantee it exists on the filesystem
+  (save-buffer)
   (let ((filename (buffer-file-name)))
     (when (and filename
                (= (buffer-size) 0))
-      (let* ((root
-              (file-name-as-directory (string-trim (shell-command-to-string (concat "juvix dev root " filename)))))
-             (relative-name
-              (file-relative-name filename root))
-             (in-project
-              (string-prefix-p root filename))
-             (module-name
-              (file-name-sans-extension (if in-project
-                                            (replace-regexp-in-string "/" "." relative-name)
-                                          (file-name-nondirectory filename)))))
-        (message "Root: %s" root)
-        (message "Relative Name: %s" relative-name)
-        (message "In Project: %s" in-project)
-        (message "Module Name: %s" module-name)
-        (insert (concat "module " module-name ";\n"))
-        (juvix-load)))))
+      (let ((res (juvix-call-read "dev" "root" filename)))
+        (when res
+          (let* ((root (file-name-as-directory (string-trim res)))
+                 (relative-name
+                  (file-relative-name filename root))
+                 (in-project
+                  (string-prefix-p root filename))
+                 (module-name
+                  (file-name-sans-extension (if in-project
+                                                (replace-regexp-in-string "/" "." relative-name)
+                                              (file-name-nondirectory filename)))))
+            (juvix-log "Root: %s" root)
+            (juvix-log "Relative Name: %s" relative-name)
+            (juvix-log "In Project: %s" in-project)
+            (juvix-log "Module Name: %s" module-name)
+            (insert (concat "module " module-name ";\n"))
+            (juvix-load)))))))
 
 (define-derived-mode juvix-mode prog-mode (juvix-version)
   (font-lock-mode 0)
@@ -99,37 +171,30 @@
   (remove-list-of-text-properties (point-min) (point-max) '(face)))
 
 (defun juvix-load ()
-  "Load current buffer."
+  "Load and highlight the current buffer."
   (interactive)
   (save-buffer)
   (juvix-clear-annotations)
-  (eval (read (shell-command-to-string
-               (concat "juvix " (concat (mapconcat 'identity juvix-global-flags " ") " ") (if juvix-disable-embedded-stdlib "--no-stdlib " "") (if juvix-stdlib-path (concat "--stdlib-path " juvix-stdlib-path " ") "") "dev highlight "
-                       (buffer-file-name)))))
-  (save-buffer)
-  (juvix-repl-load-file (buffer-file-name)))
+  (let ((res (juvix-call-read "dev" "highlight" (buffer-file-name))))
+    (when res
+      (eval (read res))
+      (save-buffer)
+      (juvix-repl-load-file (buffer-file-name)))))
 
 (defun juvix-format-buffer ()
   "Format the current buffer."
   (interactive)
   (let ((old-point (point))
-        (buff-name (buffer-file-name))
+        (file-name (buffer-file-name))
         (buff (current-buffer)))
     (with-temp-buffer
-      (let ((cmd-str (concat "juvix " (concat (mapconcat 'identity juvix-global-flags " ") " ") (if juvix-disable-embedded-stdlib "--no-stdlib " "") "format "
-                             buff-name)))
-        (if (zerop (call-process-shell-command
-                    cmd-str
-                    nil
-                    t))
-            (progn
-              (let ((text (buffer-string)))
-                (with-current-buffer buff
-                  (erase-buffer)
-                  (insert text)
-                  (goto-char old-point)
-                  (juvix-load))))
-          (message "error formatting the buffer"))))))
+      (when (zerop (juvix-call nil "format" file-name))
+        (let ((text (buffer-string)))
+          (with-current-buffer buff
+            (erase-buffer)
+            (insert text)
+            (goto-char old-point)
+            (juvix-load)))))))
 
 (defun juvix-goto-definition ()
   "Go to the definition of the symbol at point."
@@ -143,3 +208,4 @@
       (message "No goto information found at cursor"))))
 
 (provide 'juvix-mode)
+;;; juvix-mode.el ends here


### PR DESCRIPTION
Things in this pr:

1. Much cleaner code.
1. If a call to the `juvix` command crashes, the error will be displayed on a pop-up window.
2. We save the buffer before inserting the top module name to guarantee it works consistently.
3. We use a dedicated buffer to log debug messages.
4. Add necessary sections (such as `;;; Code:`) to remove warnings.