### PR TITLE
xref-psuh-marker-stack puts the marker so `xref-go-back` works

### DIFF
--- a/juvix-mode.el
+++ b/juvix-mode.el
@@ -203,6 +203,7 @@ compiler."
   "Go to the definition of the symbol at point."
   (interactive)
   (let ((goto-info (get-text-property (point) 'juvix-goto)))
+    (xref-push-marker-stack)
     (if goto-info
         (progn
           (find-file (car goto-info))


### PR DESCRIPTION
Solves #2