### PR TITLE
Fix launching the Juvix repl

### DIFF
--- a/juvix-repl.el
+++ b/juvix-repl.el
@@ -21,7 +21,7 @@
   "Run an inferior instance of `juvix repl' inside Emacs."
   (interactive)
   (let* ((juvix-program juvix-repl-program)
-         (juvix-program-args juvix-repl-program-args)
+         (juvix-program-args (juvix-repl-program-args))
          (buffer (get-buffer-create juvix-repl-buffer-name))
          (proc-alive (comint-check-proc buffer))
          (process (get-buffer-process buffer)))


### PR DESCRIPTION
`juvix-repl-program-args` is a function not a variable

(defun juvix-repl-program-args ()
  "The arguments to pass to Juvix to launch the REPL."
 (append (juvix-get-global-flags) '("repl")))

hence the change